### PR TITLE
Updated File name for DeviceBuilder.py

### DIFF
--- a/DeviceBuilder_C++IotivityServer.sh
+++ b/DeviceBuilder_C++IotivityServer.sh
@@ -44,7 +44,7 @@
 # This will have :
 # -	Input-lightdevice.json (e.g. the input file…)
 # -	out_codegeneration_merged.swagger.json : the input file for swagger2x
-# -	out_introspection_merged.swagger.json : the introspection file in json 
+# -	out_introspection_merged.swagger.json : the introspection file in json
 # -	out_introspection_merged.swagger.json.cbor : the introspection file in cbor
 # -	code (folder)
 #   - readme.txt
@@ -53,7 +53,7 @@
 
 
 PYTHON_EXE=C:\\python35-32\\python3.exe
-DeviceBuilder=./src/deviceBuilder.py
+DeviceBuilder=./src/DeviceBuilder.py
 SWAG2CBOR=./src/swag2cbor.py
 SWAGGER2XDIR=../swagger2x
 SWAGGER2X=$SWAGGER2XDIR/src/swagger2x.py
@@ -108,7 +108,7 @@ cp $INPUTFILE $OUTPUTDIR
 mkdir -p $OUTPUTDIR/code
 
 $PYTHON_EXE ./src/install.py
-$PYTHON_EXE $DeviceBuilder -input $INPUTFILE -resource_dir $MODELS_DIR -out $OUTPUTDIR/out 
+$PYTHON_EXE $DeviceBuilder -input $INPUTFILE -resource_dir $MODELS_DIR -out $OUTPUTDIR/out
 wb-swagger validate $OUTPUTDIR/out_introspection_merged.swagger.json
 $PYTHON_EXE $SWAG2CBOR -file $OUTPUTDIR/out_introspection_merged.swagger.json
 cp $OUTPUTDIR/out_introspection_merged.swagger.json.cbor $OUTPUTDIR/code/server_introspection.dat
@@ -120,6 +120,3 @@ $PYTHON_EXE $SWAGGER2X -template_dir $SWAGGER2XDIR/src/templates -template C++Io
 $PYTHON_EXE $SWAG2CBOR -file $OUTPUTDIR/code/svr_server.json
 cp $OUTPUTDIR/code/svr_server.json.cbor $OUTPUTDIR/code/server_security.dat
 cp $OUTPUTDIR/code/svr_server.json.cbor $OUTPUTDIR/code/server_security.dat-org
-
-
-

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PYTHON_EXE=C:\\python35-32\\python3.exe
-DeviceBuilder=../src/deviceBuilder.py
+DeviceBuilder=../src/DeviceBuilder.py
 SWAG2CBOR=../src/swag2cbor.py
 DIFF=../src/compareJson.py
 
@@ -46,42 +46,42 @@ function compare_json {
 function my_test {
     $PYTHON_EXE $DeviceBuilder $* > $OUTPUT_DIR/$TEST_CASE$EXT 2>&1
     compare_output
-} 
+}
 
 function my_test_in_dir {
     mkdir -p $OUTPUT_DIR/$TEST_CASE
     $PYTHON_EXE $DeviceBuilder $* > $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT 2>&1
     compare_file $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT $REF_DIR/$TEST_CASE/$TEST_CASE$EXT
-    
-    wb-swagger validate $OUTPUT_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json    
+
+    wb-swagger validate $OUTPUT_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json
     wb-swagger validate $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json
     $PYTHON_EXE $SWAG2CBOR -file $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json  #> $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT 2>&1
     $PYTHON_EXE $SWAG2CBOR -cbor $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json.cbor #> $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT 2>&1
     compare_file $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json.cbor.json
-    
+
     compare_json $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json $REF_DIR/$TEST_CASE/out_introspection_merged.swagger.json
     compare_json $OUTPUT_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json $REF_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json
     #compare_file $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json $REF_DIR/$TEST_CASE/out_introspection_merged.swagger.json
     #compare_file $OUTPUT_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json $REF_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json
-    
-} 
+
+}
 
 function my_test_in_dir_with_compare {
     mkdir -p $OUTPUT_DIR/$TEST_CASE
     $PYTHON_EXE $DeviceBuilder $* > $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT 2>&1
     compare_file $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT $REF_DIR/$TEST_CASE/$TEST_CASE$EXT
-    
-    wb-swagger validate $OUTPUT_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json    
+
+    wb-swagger validate $OUTPUT_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json
     wb-swagger validate $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json
-    
+
     $PYTHON_EXE $SWAG2CBOR -file $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json  #> $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT 2>&1
     $PYTHON_EXE $SWAG2CBOR -cbor $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json.cbor #> $OUTPUT_DIR/$TEST_CASE/$TEST_CASE$EXT 2>&1
     compare_file $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json.cbor.json
- 
+
     compare_file $OUTPUT_DIR/$TEST_CASE/out_introspection_merged.swagger.json $REF_DIR/$TEST_CASE/out_introspection_merged.swagger.json
     compare_file $OUTPUT_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json $REF_DIR/$TEST_CASE/out_codegeneration_merged.swagger.json
-    
-} 
+
+}
 
 
 
@@ -195,6 +195,6 @@ fi
 
 generic_tests
 oic_res_tests
-deviceBuilder_tests 
-deviceBuilder_tests2  
+deviceBuilder_tests
+deviceBuilder_tests2
 deviceBuilder_ctt_tests


### PR DESCRIPTION
The DeviceBuilder file name was set to
DeviceBuilder=./src/deviceBuilder.py

On Case sensitive OSs like Linux this must be
set to DeviceBuilder=./src/DeviceBulder.py

Signed-off-by: George Nash <george.nash@intel.com>