### PR TITLE
Change line-ending in bash script

### DIFF
--- a/DeviceBuilder_C++IotivityServer.sh
+++ b/DeviceBuilder_C++IotivityServer.sh
@@ -52,7 +52,7 @@
 
 
 
-PYTHON_EXE=C:\\python35-32\\python3.exe
+PYTHON_EXE=python3
 DeviceBuilder=./src/DeviceBuilder.py
 SWAG2CBOR=./src/swag2cbor.py
 SWAGGER2XDIR=../swagger2x


### PR DESCRIPTION
used dos2unix to change line endings in the
DeviceBuilder_C++IotivityServer.sh script.

The script would not run on Linux with the
dos style line endings.

Signed-off-by: George Nash <george.nash@intel.com>